### PR TITLE
Update AnalyticsManager.cs

### DIFF
--- a/SimpleAnalytics/Analytics/AnalyticsManager.cs
+++ b/SimpleAnalytics/Analytics/AnalyticsManager.cs
@@ -249,6 +249,8 @@ namespace Analytics
 
         private System.Data.DataTable BuildTableRows(Google.Apis.Analytics.v3.Data.GaData gaData, System.Data.DataTable table)
         {
+            if (gaData.Rows == null) return table;
+
             foreach (var ls in gaData.Rows)
             {
                 System.Data.DataRow row = table.NewRow();


### PR DESCRIPTION
Certain requests can cause Google.Apis.Analytics.v3.Data.GaData.Rows to be null, and throw an error. Rather than causing the error, check if this condition exists and return an empty data table, and let the client application deal with the empty table. 

I've encountered this condition when requesting things like demographics/audience, for example:

Metrics: Analytics.Data.Visitor.Metrics.visitors
Dimensions: Analytics.Data.Audience.Dimensions.visitorAgeBracket

In GA I see the message "Some data in this report may have been removed when a threshold was applied. (https://support.google.com/analytics/answer/2954071?hl=en-GB&utm_id=ad)" when accessing these same values. 
